### PR TITLE
Fixed invalid bin reference in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         ]
     },
     "bin": [
-        "composer/bin/phpunit"
+        "composer/bin/phploc"
     ],
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
It was pointing to composer/bin/phpunit instead of composer/bin/phploc. I
presume this was a copypaste error.
