### PR TITLE
Removed bin-dir override in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,5 @@
     },
     "bin": [
         "composer/bin/phploc"
-    ],
-    "config": {
-        "bin-dir": "bin"
-    }
+    ]
 }


### PR DESCRIPTION
For some reason bin-dir option was changed from the default setting of
vendor/bin to just bin. This caused bin scripts to be installed outside
the vendor subfolder, which is not standard.
