### PR TITLE
Improve composer.json dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/finder": "2.1.x-dev",
+        "symfony/finder": "~2.1",
         "zetacomponents/console-tools": "dev-master",
         "sebastian/finder-facade": ">=1.0.5"
     },


### PR DESCRIPTION
Depending on a tagged version of zetacomponents/console-tools allows installing phploc
with a default stability of stable
Also depend on stable versions of symfony/finder >= 2.1
