### PR TITLE
PHPLoc don't count tests with @test and @scenario annotations

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -555,6 +555,10 @@ namespace SebastianBergmann\PHPLOC
             }
 
             while ($tokens[$currentToken][0] != T_DOC_COMMENT) {
+                if ($tokens[$currentToken] == '{' || $tokens[$currentToken] == '}') {
+                    return false;
+                }
+
                 --$currentToken;
             }
 

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -114,10 +114,10 @@ class PHPLOC_AnalyserTest extends PHPUnit_Framework_TestCase
         $expected =
           array(
             'files' => 2,
-            'loc' => 65,
-            'nclocClasses' => 43,
-            'cloc' => 6,
-            'ncloc' => 59,
+            'loc' => 70,
+            'nclocClasses' => 47,
+            'cloc' => 7,
+            'ncloc' => 63,
             'eloc' => 28,
             'ccn' => 2,
             'ccnMethods' => 2,
@@ -137,10 +137,10 @@ class PHPLOC_AnalyserTest extends PHPUnit_Framework_TestCase
             'globalConstants' => 1,
             'testClasses' => 1,
             'testMethods' => 2,
-            'ccnByLoc' => 0.033898305084746,
+            'ccnByLoc' => 0.031746031746032,
             'ccnByNom' => 2,
-            'nclocByNoc' => 21.5,
-            'nclocByNom' => 10.75,
+            'nclocByNoc' => 23.5,
+            'nclocByNom' => 11.75,
             'directories' => 0,
             'namespaces' => 1,
             'traits' => 0

--- a/tests/_files/tests.php
+++ b/tests/_files/tests.php
@@ -7,12 +7,17 @@ class ATest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider barProvider
      */
     public function bar()
     {
     }
 
     protected function doSomething()
+    {
+    }
+
+    public function barProvider()
     {
     }
 }


### PR DESCRIPTION
PHPUnit allows the use of @test and @scenario annotations, but PHPLoc just count test methods with the "test" prefix.

This change fixes that.
