### PR TITLE
Git traverse fails with exception on missing directory

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -250,8 +250,12 @@ namespace SebastianBergmann\PHPLOC\CLI
 
         private function count(array $arguments, $excludes, $names, $namesExclude, $countTests)
         {
-            $finder = new FinderFacade($arguments, $excludes, $names, $namesExclude);
-            $files  = $finder->findFiles();
+            try {
+                $finder = new FinderFacade($arguments, $excludes, $names, $namesExclude);
+                $files  = $finder->findFiles();
+            } catch (\InvalidArgumentException $ex) {
+                return FALSE;
+            }
 
             if (empty($files)) {
                 return FALSE;


### PR DESCRIPTION
When running with the --git-repository flag the processing stops when a folder is missing within a commit, since the Finder component is throwing an InvalidArgumentException.

Use case:
`phploc --log-csv log.csv --progress --count-tests --git-repository . src` produces

`[InvalidArgumentException]  The "/path/to/src" directory does not exist.` when the src folder was removed within a revision, and added later on.
