### PR TITLE
Fix infinite loop in `isTestClass`

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -680,16 +680,22 @@ namespace SebastianBergmann\PHPLOC
         {
             $parent = $this->classes[$className];
             $result = FALSE;
-
+            $count = 0;
+            
             // Check ancestry for PHPUnit_Framework_TestCase.
             while ($parent !== NULL) {
+                $count++;
+                if ($count > 100) {
+                    // Prevent infinite loops and just bail
+                    break;
+                }
                 if ($parent == 'PHPUnit_Framework_TestCase' ||
                     $parent == '\\PHPUnit_Framework_TestCase') {
                     $result = TRUE;
                     break;
                 }
 
-                if (isset($this->classes[$parent])) {
+                if (isset($this->classes[$parent]) && $parent !== $this->classes[$parent]) {
                     $parent = $this->classes[$parent];
                 }
 


### PR DESCRIPTION
This fixes a case where an infinite loop can be encountered with HHVM when parsing code like this: https://github.com/zendframework/zf2/blob/fc64ed00440fe1948b8cb41d3b08c5f2b08c45bb/library/Zend/Mime/Exception/RuntimeException.php#L35

It appears that this may be due to a namespace detection issue, but ultimately putting a bound on the loop isn't a bad idea either.
