### PR TITLE
Simplify CSV creation + add tests

### DIFF
--- a/src/Log/CSV/Single.php
+++ b/src/Log/CSV/Single.php
@@ -55,6 +55,55 @@ namespace SebastianBergmann\PHPLOC\Log\CSV
     class Single
     {
         /**
+         * Mapping between internal and human-readable metric names
+         *
+         * @var array
+         */
+        private $colmap = array(
+            'directories' => 'Directories',
+            'files' => 'Files',
+            'loc' => 'Lines of Code (LOC)',
+            'ccnByLloc' => 'Cyclomatic Complexity / Lines of Code',
+            'cloc' => 'Comment Lines of Code (CLOC)',
+            'ncloc' => 'Non-Comment Lines of Code (NCLOC)',
+            'lloc' => 'Logical Lines of Code (LLOC)',
+            'llocGlobal' => 'LLOC outside functions or classes',
+            'namespaces' => 'Namespaces',
+            'interfaces' => 'Interfaces',
+            'traits' => 'Traits',
+            'classes' => 'Classes',
+            'abstractClasses' => 'Abstract Classes',
+            'concreteClasses' => 'Concrete Classes',
+            'llocClasses' => 'Classes Length (LLOC)',
+            'methods' => 'Methods',
+            'nonStaticMethods' => 'Non-Static Methods',
+            'staticMethods' => 'Static Methods',
+            'publicMethods' => 'Public Methods',
+            'nonPublicMethods' => 'Non-Public Methods',
+            'methodCcnAvg' => 'Cyclomatic Complexity / Number of Methods',
+            'functions' => 'Functions',
+            'namedFunctions' => 'Named Functions',
+            'anonymousFunctions' => 'Anonymous Functions',
+            'llocFunctions' => 'Functions Length (LLOC)',
+            'llocByNof' => 'Average Function Length (LLOC)',
+            'constants' => 'Constants',
+            'globalConstants' => 'Global Constants',
+            'classConstants' => 'Class Constants',
+            'attributeAccesses' => 'Attribute Accesses',
+            'instanceAttributeAccesses' => 'Non-Static Attribute Accesses',
+            'staticAttributeAccesses' => 'Static Attribute Accesses',
+            'methodCalls' => 'Method Calls',
+            'instanceMethodCalls' => 'Non-Static Method Calls',
+            'staticMethodCalls' => 'Static Method Calls',
+            'globalAccesses' => 'Global Accesses',
+            'globalVariableAccesses' => 'Global Variable Accesses',
+            'superGlobalVariableAccesses' => 'Super-Global Variable Accesses',
+            'globalConstantAccesses' => 'Global Constant Accesses',
+            'testClasses' => 'Test Classes',
+            'testMethods' => 'Test Methods'
+        );
+        
+        /**
          * Prints a result set.
          *
          * @param string $filename
@@ -74,102 +123,24 @@ namespace SebastianBergmann\PHPLOC\Log\CSV
          */
         protected function getKeysLine(array $count)
         {
-            $keys = array(
-              'Directories',
-              'Files',
-              'Lines of Code (LOC)',
-              'Cyclomatic Complexity / Lines of Code',
-              'Comment Lines of Code (CLOC)',
-              'Non-Comment Lines of Code (NCLOC)',
-              'Logical Lines of Code (LLOC)',
-              'LLOC outside functions or classes',
-              'Namespaces',
-              'Interfaces',
-              'Traits',
-              'Classes',
-              'Abstract Classes',
-              'Concrete Classes',
-              'Classes Length (LLOC)',
-              'Methods',
-              'Non-Static Methods',
-              'Static Methods',
-              'Public Methods',
-              'Non-Public Methods',
-              'Cyclomatic Complexity / Number of Methods',
-              'Functions',
-              'Named Functions',
-              'Anonymous Functions',
-              'Functions Length (LLOC)',
-              'Average Function Length (LLOC)',
-              'Constants',
-              'Global Constants',
-              'Class Constants',
-              'Attribute Accesses',
-              'Non-Static Attribute Accesses',
-              'Static Attribute Accesses',
-              'Method Calls',
-              'Non-Static Method Calls',
-              'Static Method Calls',
-              'Global Accesses',
-              'Global Variable Accesses',
-              'Super-Global Variable Accesses',
-              'Global Constant Accesses',
-              'Test Classes',
-              'Test Methods'
-            );
-
-            return implode(',', $keys) . PHP_EOL;
+            return implode(',', array_values($this->colmap)) . PHP_EOL;
         }
 
         /**
          * @param  array $count
+         * @throws \InvalidArgumentException
          * @return string
          */
         protected function getValuesLine(array $count)
         {
-            $values = array(
-              $count['directories'],
-              $count['files'],
-              $count['loc'],
-              $count['ccnByLloc'],
-              $count['cloc'],
-              $count['ncloc'],
-              $count['lloc'],
-              $count['llocGlobal'],
-              $count['namespaces'],
-              $count['interfaces'],
-              $count['traits'],
-              $count['classes'],
-              $count['abstractClasses'],
-              $count['concreteClasses'],
-              $count['llocClasses'],
-              $count['methods'],
-              $count['nonStaticMethods'],
-              $count['staticMethods'],
-              $count['publicMethods'],
-              $count['nonPublicMethods'],
-              $count['methodCcnAvg'],
-              $count['functions'],
-              $count['namedFunctions'],
-              $count['anonymousFunctions'],
-              $count['llocFunctions'],
-              $count['llocByNof'],
-              $count['constants'],
-              $count['globalConstants'],
-              $count['classConstants'],
-              $count['attributeAccesses'],
-              $count['instanceAttributeAccesses'],
-              $count['staticAttributeAccesses'],
-              $count['methodCalls'],
-              $count['instanceMethodCalls'],
-              $count['staticMethodCalls'],
-              $count['globalAccesses'],
-              $count['globalVariableAccesses'],
-              $count['superGlobalVariableAccesses'],
-              $count['globalConstantAccesses'],
-              $count['testClasses'],
-              $count['testMethods']
-            );
+            $values = array();
+            foreach ($this->colmap as $key => $name) {
+                if (isset($count[$key])) {
+                    $values[] = $count[$key];
+                } else {
+                    throw new \InvalidArgumentException('Attempted to print row with missing keys');
+                }
+            }
 
             return '"' . implode('","', $values) . '"' . PHP_EOL;
         }

--- a/tests/Log/CSV/HistoryTest.php
+++ b/tests/Log/CSV/HistoryTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * PHPLOC
+ *
+ * Copyright (c) 2009-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPLOC
+ * @subpackage Tests
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2009-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ */
+
+class HistoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \SebastianBergmann\PHPLOC\Log\CSV\Single
+     */
+    private $history;
+
+    private $sample_data = array(
+        '2014-06-09T00:00:00'=>array(
+            'commit' => 'foo',
+            'directories' => 1,
+            'files' => 2,
+            'loc' => 3,
+            'ccnByLloc' => 4,
+            'cloc' => 5,
+            'ncloc' => 6,
+            'lloc' => 7,
+            'llocGlobal' => 8,
+            'namespaces' => 9,
+            'interfaces' => 10,
+            'traits' => 11,
+            'classes' => 12,
+            'abstractClasses' => 13,
+            'concreteClasses' => 14,
+            'llocClasses' => 15,
+            'methods' => 16,
+            'nonStaticMethods' => 17,
+            'staticMethods' => 18,
+            'publicMethods' => 19,
+            'nonPublicMethods' => 20,
+            'methodCcnAvg' => 21,
+            'functions' => 22,
+            'namedFunctions' => 23,
+            'anonymousFunctions' => 24,
+            'llocFunctions' => 25,
+            'llocByNof' => 26,
+            'constants' => 27,
+            'globalConstants' => 28,
+            'classConstants' => 29,
+            'attributeAccesses' => 30,
+            'instanceAttributeAccesses' => 31,
+            'staticAttributeAccesses' => 32,
+            'methodCalls' => 33,
+            'instanceMethodCalls' => 34,
+            'staticMethodCalls' => 35,
+            'globalAccesses' => 36,
+            'globalVariableAccesses' => 37,
+            'superGlobalVariableAccesses' => 38,
+            'globalConstantAccesses' => 39,
+            'testClasses' => 40,
+            'testMethods' => 41
+        ),
+        '2014-07-09T00:00:00'=>array(
+            'commit' => 'bar',
+            'directories' => 42,
+            'files' => 43,
+            'loc' => 44,
+            'ccnByLloc' => 45,
+            'cloc' => 46,
+            'ncloc' => 47,
+            'lloc' => 48,
+            'llocGlobal' => 49,
+            'namespaces' => 50,
+            'interfaces' => 51,
+            'traits' => 52,
+            'classes' => 53,
+            'abstractClasses' => 54,
+            'concreteClasses' => 55,
+            'llocClasses' => 56,
+            'methods' => 57,
+            'nonStaticMethods' => 58,
+            'staticMethods' => 59,
+            'publicMethods' => 60,
+            'nonPublicMethods' => 61,
+            'methodCcnAvg' => 62,
+            'functions' => 63,
+            'namedFunctions' => 64,
+            'anonymousFunctions' => 65,
+            'llocFunctions' => 66,
+            'llocByNof' => 67,
+            'constants' => 68,
+            'globalConstants' => 69,
+            'classConstants' => 70,
+            'attributeAccesses' => 71,
+            'instanceAttributeAccesses' => 72,
+            'staticAttributeAccesses' => 73,
+            'methodCalls' => 74,
+            'instanceMethodCalls' => 75,
+            'staticMethodCalls' => 76,
+            'globalAccesses' => 77,
+            'globalVariableAccesses' => 78,
+            'superGlobalVariableAccesses' => 79,
+            'globalConstantAccesses' => 80,
+            'testClasses' => 81,
+            'testMethods' => 82
+        )
+    );
+
+    public function setUp()
+    {
+        $this->history = new \SebastianBergmann\PHPLOC\Log\CSV\History();
+    }
+
+    public function testPrintedResultContainsHeadings()
+    {
+        ob_start();
+        $this->history->printResult('php://output', $this->sample_data);
+        $output = ob_get_clean();
+
+        $this->assertRegExp('#^Date,Commit,Directories,Files.+$#mis', $output, "Printed result does not contain a heading line");
+    }
+
+    public function testPrintedResultContainsData()
+    {
+        ob_start();
+        $this->history->printResult('php://output', $this->sample_data);
+        $output = ob_get_clean();
+
+        $this->assertRegExp('#^2014-06-09T00:00:00,"foo","1".+$#mis', $output, "Printed result does not contain a value line");
+    }
+
+    public function testExactlyThreeRowsArePrinted()
+    {
+        ob_start();
+        $this->history->printResult('php://output', $this->sample_data);
+        $output = ob_get_clean();
+
+        $rows = explode("\n", trim($output));
+        $this->assertEquals(3, count($rows), "Printed result contained more or less than expected 2 rows");
+    }
+}

--- a/tests/Log/CSV/SingleTest.php
+++ b/tests/Log/CSV/SingleTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * PHPLOC
+ *
+ * Copyright (c) 2009-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPLOC
+ * @subpackage Tests
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2009-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ */
+
+class SingleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \SebastianBergmann\PHPLOC\Log\CSV\Single
+     */
+    private $single;
+
+    private $sample_row = array(
+        'directories' => 1,
+        'files' => 2,
+        'loc' => 3,
+        'ccnByLloc' => 4,
+        'cloc' => 5,
+        'ncloc' => 6,
+        'lloc' => 7,
+        'llocGlobal' => 8,
+        'namespaces' => 9,
+        'interfaces' => 10,
+        'traits' => 11,
+        'classes' => 12,
+        'abstractClasses' => 13,
+        'concreteClasses' => 14,
+        'llocClasses' => 15,
+        'methods' => 16,
+        'nonStaticMethods' => 17,
+        'staticMethods' => 18,
+        'publicMethods' => 19,
+        'nonPublicMethods' => 20,
+        'methodCcnAvg' => 21,
+        'functions' => 22,
+        'namedFunctions' => 23,
+        'anonymousFunctions' => 24,
+        'llocFunctions' => 25,
+        'llocByNof' => 26,
+        'constants' => 27,
+        'globalConstants' => 28,
+        'classConstants' => 29,
+        'attributeAccesses' => 30,
+        'instanceAttributeAccesses' => 31,
+        'staticAttributeAccesses' => 32,
+        'methodCalls' => 33,
+        'instanceMethodCalls' => 34,
+        'staticMethodCalls' => 35,
+        'globalAccesses' => 36,
+        'globalVariableAccesses' => 37,
+        'superGlobalVariableAccesses' => 38,
+        'globalConstantAccesses' => 39,
+        'testClasses' => 40,
+        'testMethods' => 41
+    );
+
+    public function setUp()
+    {
+        $this->single = new \SebastianBergmann\PHPLOC\Log\CSV\Single();
+    }
+
+    public function testPrintedResultContainsHeadings()
+    {
+        ob_start();
+        $this->single->printResult('php://output', $this->sample_row);
+        $output = ob_get_clean();
+
+        $this->assertRegExp('#Directories,Files.+$#is', $output, "Printed result does not contain a heading line");
+    }
+
+    public function testPrintedResultContainsData()
+    {
+        ob_start();
+        $this->single->printResult('php://output', $this->sample_row);
+        $output = ob_get_clean();
+
+        $this->assertRegExp('#"1","2".+$#is', $output, "Printed result does not contain a value line");
+    }
+
+    public function testPrintedResultContainsEqualNumHeadingsAndValues()
+    {
+        ob_start();
+        $this->single->printResult('php://output', $this->sample_row);
+        $output = ob_get_clean();
+
+        $rows = explode("\n", $output);
+        $headings = explode(",", $rows[0]);
+        $vals = explode(",", $rows[1]);
+
+        $this->assertEquals(
+            count($headings),
+            count($vals),
+            "Printed result does not contain same number of headings and values"
+        );
+    }
+
+    public function testExactlyTwoRowsArePrinted()
+    {
+        ob_start();
+        $this->single->printResult('php://output', $this->sample_row);
+        $output = ob_get_clean();
+
+        $rows = explode("\n", trim($output));
+        $this->assertEquals(2, count($rows), "Printed result contained more or less than expected 2 rows");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPrintPartialRow()
+    {
+        $count = $this->sample_row;
+        unset($count['llocByNof']);
+
+        ob_start();
+        $this->single->printResult('php://output', $count);
+        ob_end_clean();
+
+        $this->fail("No exception was raised for malformed input var");
+    }
+}


### PR DESCRIPTION
Currently it's quite easy to introduce regressions into the CSV writer classes because of the way the keys and values are separated.  This pull request alters the way lines are written to prevent headings going out of line with values. Also I've covered both CSV classes with basic tests.

I think the writer classes would be easier to test if they took an \SplFileObject instead of a filename. Any thoughts on that?
