### PR TITLE
Make installable on php 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/sebastianbergmann/phploc/issues"
     },
     "require": {
-        "php": "~5.4",
+        "php": ">=5.4",
         "sebastian/finder-facade": "~1.1",
         "sebastian/git": "~2.0",
         "sebastian/version": "~1.0.3",


### PR DESCRIPTION
php7 is in our travis build file, yet we're marking it as not supported?