### PR TITLE
Provide human readable names of metrics in xml report

### DIFF
--- a/src/Log/XML.php
+++ b/src/Log/XML.php
@@ -18,6 +18,66 @@ namespace SebastianBergmann\PHPLOC\Log;
 class XML
 {
     /**
+     * Mapping between internal and human-readable metric names
+     *
+     * @var array
+     */
+    private $colmap = array(
+        'directories'                 => 'Directories',
+        'files'                       => 'Files',
+        'loc'                         => 'Lines of Code (LOC)',
+        'ccnByLloc'                   => 'Cyclomatic Complexity / Lines of Code',
+        'cloc'                        => 'Comment Lines of Code (CLOC)',
+        'ncloc'                       => 'Non-Comment Lines of Code (NCLOC)',
+        'lloc'                        => 'Logical Lines of Code (LLOC)',
+        'llocGlobal'                  => 'LLOC outside functions or classes',
+        'namespaces'                  => 'Namespaces',
+        'interfaces'                  => 'Interfaces',
+        'traits'                      => 'Traits',
+        'classes'                     => 'Classes',
+        'abstractClasses'             => 'Abstract Classes',
+        'concreteClasses'             => 'Concrete Classes',
+        'llocClasses'                 => 'Classes Length (LLOC)',
+        'methods'                     => 'Methods',
+        'nonStaticMethods'            => 'Non-Static Methods',
+        'staticMethods'               => 'Static Methods',
+        'publicMethods'               => 'Public Methods',
+        'nonPublicMethods'            => 'Non-Public Methods',
+        'classLlocAvg'                => 'Average Class Length (LLOC)',
+        'classLlocMin'                => 'Minimum Class Length (LLOC)',
+        'classLlocMax'                => 'Maximum Class Length (LLOC)',
+        'classCcnAvg'                 => 'Cyclomatic Complexity / Number of Classes',
+        'classCcnMin'                 => 'Minimum Class Complexity',
+        'classCcnMax'                 => 'Maximum Class Complexity',
+        'methodLlocAvg'               => 'Average Method Length (LLOC)',
+        'methodLlocMin'               => 'Minimal Method Length (LLOC)',
+        'methodLlocMax'               => 'Maximal Method Length (LLOC)',
+        'methodCcnAvg'                => 'Cyclomatic Complexity / Number of Methods',
+        'methodCcnMin'                => 'Minimum Method Complexity',
+        'methodCcnMax'                => 'Maximum Method Complexity',
+        'functions'                   => 'Functions',
+        'namedFunctions'              => 'Named Functions',
+        'anonymousFunctions'          => 'Anonymous Functions',
+        'llocFunctions'               => 'Functions Length (LLOC)',
+        'llocByNof'                   => 'Average Function Length (LLOC)',
+        'constants'                   => 'Constants',
+        'globalConstants'             => 'Global Constants',
+        'classConstants'              => 'Class Constants',
+        'attributeAccesses'           => 'Attribute Accesses',
+        'instanceAttributeAccesses'   => 'Non-Static Attribute Accesses',
+        'staticAttributeAccesses'     => 'Static Attribute Accesses',
+        'methodCalls'                 => 'Method Calls',
+        'instanceMethodCalls'         => 'Non-Static Method Calls',
+        'staticMethodCalls'           => 'Static Method Calls',
+        'globalAccesses'              => 'Global Accesses',
+        'globalVariableAccesses'      => 'Global Variable Accesses',
+        'superGlobalVariableAccesses' => 'Super-Global Variable Accesses',
+        'globalConstantAccesses'      => 'Global Constant Accesses',
+        'testClasses'                 => 'Test Classes',
+        'testMethods'                 => 'Test Methods'
+    );
+
+    /**
      * Prints a result set.
      *
      * @param string $filename
@@ -45,9 +105,15 @@ class XML
         unset($count['files']);
 
         foreach ($count as $k => $v) {
-            $root->appendChild(
+            $metric = $root->appendChild(
                 $document->createElement($k, $v)
             );
+            if (isset($this->colmap[$k])) {
+                $metric->setAttribute("name", $this->colmap[$k]);
+            }
+            else {
+                $metric->setAttribute("name", '');
+            }
         }
 
         file_put_contents($filename, $document->saveXML());


### PR DESCRIPTION
Adds human readable name of the metrics as `name` attribute to xml elements.

#### Sample Output

```xml
<?xml version="1.0" encoding="UTF-8"?>
<phploc>
  <directories>13</directories>
  <files>60</files>
  <loc name="Lines of Code (LOC)">7026</loc>
  <lloc name="Logical Lines of Code (LLOC)">1428</lloc>
  <llocClasses name="Classes Length (LLOC)">1422</llocClasses>
  <llocFunctions name="Functions Length (LLOC)">5</llocFunctions>
  <llocGlobal name="LLOC outside functions or classes">1</llocGlobal>
  <cloc name="Comment Lines of Code (CLOC)">2197</cloc>
  <ccn name="">581</ccn>
  <ccnMethods name="">578</ccnMethods>
  <interfaces name="Interfaces">0</interfaces>
  <traits name="Traits">0</traits>
  <classes name="Classes">60</classes>
  <abstractClasses name="Abstract Classes">1</abstractClasses>
  <concreteClasses name="Concrete Classes">59</concreteClasses>
  <functions name="Functions">3</functions>
  <namedFunctions name="Named Functions">1</namedFunctions>
  <anonymousFunctions name="Anonymous Functions">2</anonymousFunctions>
  <methods name="Methods">504</methods>
  <publicMethods name="Public Methods">504</publicMethods>
  <nonPublicMethods name="Non-Public Methods">0</nonPublicMethods>
  <nonStaticMethods name="Non-Static Methods">504</nonStaticMethods>
  <staticMethods name="Static Methods">0</staticMethods>
  <constants name="Constants">5</constants>
  <classConstants name="Class Constants">5</classConstants>
  <globalConstants name="Global Constants">0</globalConstants>
  <testClasses name="Test Classes">0</testClasses>
  <testMethods name="Test Methods">0</testMethods>
  <ccnByLloc name="Cyclomatic Complexity / Lines of Code">0.40686274509804</ccnByLloc>
  <llocByNof name="Average Function Length (LLOC)">1.6666666666667</llocByNof>
  <methodCalls name="Method Calls">178</methodCalls>
  <staticMethodCalls name="Static Method Calls">37</staticMethodCalls>
  <instanceMethodCalls name="Non-Static Method Calls">141</instanceMethodCalls>
  <attributeAccesses name="Attribute Accesses">473</attributeAccesses>
  <staticAttributeAccesses name="Static Attribute Accesses">0</staticAttributeAccesses>
  <instanceAttributeAccesses name="Non-Static Attribute Accesses">473</instanceAttributeAccesses>
  <globalAccesses name="Global Accesses">2</globalAccesses>
  <globalVariableAccesses name="Global Variable Accesses">2</globalVariableAccesses>
  <superGlobalVariableAccesses name="Super-Global Variable Accesses">0</superGlobalVariableAccesses>
  <globalConstantAccesses name="Global Constant Accesses">0</globalConstantAccesses>
  <classCcnMin name="Minimum Class Complexity">1</classCcnMin>
  <classCcnAvg name="Cyclomatic Complexity / Number of Classes">10.633333333333</classCcnAvg>
  <classCcnMax name="Maximum Class Complexity">48</classCcnMax>
  <classLlocMin name="Minimum Class Length (LLOC)">5</classLlocMin>
  <classLlocAvg name="Average Class Length (LLOC)">23.7</classLlocAvg>
  <classLlocMax name="Maximum Class Length (LLOC)">88</classLlocMax>
  <methodCcnMin name="Minimum Method Complexity">1</methodCcnMin>
  <methodCcnAvg name="Cyclomatic Complexity / Number of Methods">2.1336032388664</methodCcnAvg>
  <methodCcnMax name="Maximum Method Complexity">38</methodCcnMax>
  <methodLlocMin name="Minimal Method Length (LLOC)">0</methodLlocMin>
  <methodLlocAvg name="Average Method Length (LLOC)">2.7712550607287</methodLlocAvg>
  <methodLlocMax name="Maximal Method Length (LLOC)">56</methodLlocMax>
  <namespaces name="Namespaces">0</namespaces>
  <ncloc name="Non-Comment Lines of Code (NCLOC)">4829</ncloc>
</phploc>
```