### PR TITLE
Stream output to the CSV rather than batching it

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -163,8 +163,12 @@ class Command extends AbstractCommand
         $git            = new Git($input->getOption('git-repository'));
         $currentBranch  = $git->getCurrentBranch();
         $revisions      = $git->getRevisions();
-        $count          = [];
+        $printer        = null;
         $progressBar    = null;
+
+        if ($input->getOption('log-csv')) {
+            $printer = new History($input->getOption('log-csv'));
+        }
 
         if ($input->getOption('progress')) {
             $progressBar = new ProgressBar($output, count($revisions));
@@ -193,8 +197,11 @@ class Command extends AbstractCommand
             );
 
             if ($_count) {
-                $_count['commit']                                 = $revision['sha1'];
-                $count[$revision['date']->format(\DateTime::W3C)] = $_count;
+                $_count['commit'] = $revision['sha1'];
+                $_count['date']   = $revision['date']->format(\DateTime::W3C);
+                if ($printer) {
+                    $printer->printRow($_count);
+                }
             }
 
             if ($progressBar !== null) {
@@ -209,10 +216,6 @@ class Command extends AbstractCommand
             $output->writeln('');
         }
 
-        if ($input->getOption('log-csv')) {
-            $printer = new History;
-            $printer->printResult($input->getOption('log-csv'), $count);
-        }
     }
 
     private function count(array $arguments, $excludes, $names, $namesExclude, $countTests)

--- a/tests/Log/CSV/HistoryTest.php
+++ b/tests/Log/CSV/HistoryTest.php
@@ -16,7 +16,8 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
     private $history;
 
     private $sample_data = [
-        '2014-06-09T00:00:00' => [
+        [
+            'date' => '2014-06-09T00:00:00',
             'commit' => 'foo',
             'directories' => 1,
             'files' => 2,
@@ -60,7 +61,8 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
             'testClasses' => 40,
             'testMethods' => 41
         ],
-        '2014-07-09T00:00:00' => [
+        [
+            'date' => '2014-07-09T00:00:00',
             'commit' => 'bar',
             'directories' => 42,
             'files' => 43,
@@ -108,13 +110,15 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->history = new \SebastianBergmann\PHPLOC\Log\CSV\History();
+        $this->history = new \SebastianBergmann\PHPLOC\Log\CSV\History('php://output');
     }
 
     public function testPrintedResultContainsHeadings()
     {
         ob_start();
-        $this->history->printResult('php://output', $this->sample_data);
+        foreach ($this->sample_data as $row) {
+            $this->history->printRow($row);
+        }
         $output = ob_get_clean();
 
         $this->assertRegExp('#^Date,Commit,Directories,Files.+$#mis', $output, "Printed result does not contain a heading line");
@@ -123,7 +127,9 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
     public function testPrintedResultContainsData()
     {
         ob_start();
-        $this->history->printResult('php://output', $this->sample_data);
+        foreach ($this->sample_data as $row) {
+            $this->history->printRow($row);
+        }
         $output = ob_get_clean();
 
         $this->assertRegExp('#^2014-06-09T00:00:00,"foo","1".+$#mis', $output, "Printed result does not contain a value line");
@@ -132,7 +138,9 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
     public function testExactlyThreeRowsArePrinted()
     {
         ob_start();
-        $this->history->printResult('php://output', $this->sample_data);
+        foreach ($this->sample_data as $row) {
+            $this->history->printRow($row);
+        }
         $output = ob_get_clean();
 
         $rows = explode("\n", trim($output));


### PR DESCRIPTION
Stream the output to the CSV instead of batching it.

This will open a log file and write results to it as they are processed.