### PR TITLE
Separating results of multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,33 @@ Make sure you have `~/.composer/vendor/bin/` in your path.
     phploc 2.0.4 by Sebastian Bergmann.
 
      295/295 [============================] 100%
+
+### Analyse multiple directories and separate results
+
+By using `--separate` option, you can analyse multiple directories and output their results separately, which are normally merged together. This option will let you output one CSV or XML file, with each directory you provided represented as a separate entity.
+
+    ➜ ~ phploc ~/web_project ~/cli_project --separate --log-csv results.csv
+    phploc 2.0.4 by Sebastian Bergmann.
+
+    Project Directory                           ~/web_project
+    Directories                                          3
+    Files                                                8
+
+    Size
+      Lines of Code (LOC)                             1858
+      Comment Lines of Code (CLOC)                     560 (30.14%)
+      Non-Comment Lines of Code (NCLOC)               1298 (69.86%)
+      .....
+      
+      
+    
+    
+    Project Directory                           ~/cli_project
+    Directories                                          2
+    Files                                                9
+
+    Size
+      Lines of Code (LOC)                             1858
+      Comment Lines of Code (CLOC)                     560 (30.14%)
+      Non-Comment Lines of Code (NCLOC)               1298 (69.86%)
+      .....

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -314,7 +314,7 @@ class Analyser
                     if ($className !== null) {
                         $this->count['ccnMethods']++;
                         $currentClassData['ccn']++;
-                        $currentMethodData['ccn']++;
+                        if(isset($currentMethodData['ccn'])) $currentMethodData['ccn']++;
                     }
 
                     $this->count['ccn']++;

--- a/src/Log/CSV/Single.php
+++ b/src/Log/CSV/Single.php
@@ -81,11 +81,36 @@ class Single
     }
 
     /**
+     * Adds a new result line to the file. Will create and add headers if this is the first attempt.
+     *
+     * @param string $filename
+     * @param array $count
+     */
+    public function addResult($filename, array $count)
+    {
+        static $createdFirstLine = false;
+
+        if($createdFirstLine) {
+            file_put_contents($filename, file_get_contents($filename).$this->getValuesLine($count));
+        } else {
+            $this->printResult($filename, $count);
+            $createdFirstLine = true;
+        }
+    }
+
+    /**
      * @param  array  $count
      * @return string
      */
     protected function getKeysLine(array $count)
     {
+        if(isset($count['project_directory'])) {
+            $this->colmap = array_merge(
+                ['project_directory' => 'Project Directory'],
+                $this->colmap
+            );
+        }
+
         return implode(',', array_values($this->colmap)) . PHP_EOL;
     }
 
@@ -97,6 +122,13 @@ class Single
     protected function getValuesLine(array $count)
     {
         $values = [];
+
+        if(isset($count['project_directory']) && !isset($this->colmap['project_directory'])) {
+            $this->colmap = array_merge(
+                ['project_directory' => 'Project Directory'],
+                $this->colmap
+            );
+        }
 
         foreach ($this->colmap as $key => $name) {
             if (isset($count[$key])) {

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -32,7 +32,7 @@ class Text
             if(isset($count['project_directory'])) {
                 $output->write(
                     sprintf(
-                        "\n\nProject directory                                 %s\n",
+                        "\n\nProject Directory                                 %s\n",
                         $count['project_directory']
                     )
                 );

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -29,6 +29,15 @@ class Text
     public function printResult(OutputInterface $output, array $count, $printTests)
     {
         if ($count['directories'] > 0) {
+            if(isset($count['project_directory'])) {
+                $output->write(
+                    sprintf(
+                        "\n\nProject directory                                 %s\n",
+                        $count['project_directory']
+                    )
+                );
+            }
+
             $output->write(
                 sprintf(
                     "Directories                                 %10d\n" .

--- a/src/Log/XML.php
+++ b/src/Log/XML.php
@@ -18,7 +18,12 @@ namespace SebastianBergmann\PHPLOC\Log;
 class XML
 {
     /**
-     * Prints a result set.
+     * @var \DOMDocument
+     */
+    protected $document;
+
+    /**
+     * Prints a result set from scratch.
      *
      * @param string $filename
      * @param array  $count
@@ -52,4 +57,93 @@ class XML
 
         file_put_contents($filename, $document->saveXML());
     }
+
+    /**
+     * Get the XML document that we are working on.
+     *
+     * @param $filename
+     * @return \DOMDocument
+     * @throws \DOMException
+     */
+    private function getDocument($filename)
+    {
+        static $createdFile = false;
+
+        if($this->document instanceof \DOMDocument) {
+            return $this->document;
+        }
+
+        if($createdFile === true && file_exists($filename)) {
+            $document = new \DOMDocument();
+
+            if($document->load($filename)) {
+                $this->document = $document;
+
+                return $this->document;
+            } else {
+                throw new \DOMException();
+            }
+        }
+
+        $document               = new \DOMDocument('1.0', 'UTF-8');
+        $document->formatOutput = true;
+
+        $root = $document->createElement('phploc');
+        $document->appendChild($root);
+
+        file_put_contents($filename, $document->saveXML());
+        $createdFile = true;
+
+        $this->document = $document;
+
+        return $this->document;
+    }
+
+    /**
+     * Adds a new result set to the XML file.
+     *
+     * @param $filename
+     * @param array $count
+     * @throws \DOMException
+     */
+    public function addResult($filename, array $count)
+    {
+        $document = $this->getDocument($filename);
+        $root = $document->getElementsByTagName('phploc');
+
+        if($root->length < 1) {
+            throw new \DOMException('Could not find phploc element in the XML file.');
+        }
+
+        $root = $root->item(0);
+
+        if(isset($count['project_directory'])) {
+            $project = $document->createElement('project');
+            $project->setAttribute('directory', $count['project_directory']);
+
+            $root = $root->appendChild($project);
+        }
+
+        if ($count['directories'] > 0) {
+            $root->appendChild(
+                $document->createElement('directories', $count['directories'])
+            );
+
+            $root->appendChild(
+                $document->createElement('files', $count['files'])
+            );
+        }
+
+        unset($count['directories']);
+        unset($count['files']);
+
+        foreach ($count as $k => $v) {
+            $root->appendChild(
+                $document->createElement($k, $v)
+            );
+        }
+
+        file_put_contents($filename, $document->saveXML());
+    }
+
 }

--- a/tests/Log/CSV/SingleTest.php
+++ b/tests/Log/CSV/SingleTest.php
@@ -123,4 +123,24 @@ class SingleTest extends \PHPUnit_Framework_TestCase
 
         $this->fail("No exception was raised for malformed input var");
     }
+
+    public function testProjectSeparation()
+    {
+        $sample1 = array_merge(['project_directory' => rand()], $this->sample_row);
+        $sample2 = array_merge(['project_directory' => rand()], $this->sample_row);
+
+        // Clean previous CSV file.
+        $this->setUp();
+
+        ob_start();
+        $this->single->addResult('php://output', $sample1);
+        $this->single->addResult('php://output', $sample2);
+        $output = ob_get_clean();
+
+        $this->assertRegExp('#Project Directory,Directories,Files.+$#is', $output, "Printed result does not contain project directory header");
+
+        $rows = explode("\n", trim($output));
+        $this->assertEquals(3, count($rows), "Printed result contained more or less than expected 3 rows (1 header and 2 project lines)");
+    }
+
 }


### PR DESCRIPTION
Hello Sebastian,

I wanted to analyse multiple projects at the same time and save their results in a CSV file to be able to compare their stats. So here we now have `--separate` toggle.

**Purpose:** 
Separates the output of multiple directories provided by the user (not inner directories scanned by `phploc`).

**Affected components:**
- Log\Text: Adds a "Project Directory" line at the beginning of each result set.
- Log\XML: Wraps each output with a `<project directory="~/my_project_1"/>` tag.
- Log\CSV\Single: Adds a new header `project_directory`. Appends each result set as a new line.
- New CLI argument: `separate` with description "Separate results for each directory".
- On Log\XML and Log\CSV\Single classes, `printResult()` methods are practically absolute, but still left them or tried to make use of them.


**Warning:** 
History classes and methods do not implement this option yet. So `CLI\Command::executeHistory()` and `Log\CSV\History` will need to be updated.

Let me know what you think :)

Thanks,
Oytun