### PR TITLE
Allow Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
     - DEPENDENCIES="high"
     - DEPENDENCIES="low"
 
+matrix:
+  include:
+    - php: 7.1
+      env: DEPENDENCIES=beta
+
 sudo: false
 
 before_install:
@@ -21,6 +26,7 @@ before_install:
   - if [ $(phpenv version-name) != "5.6" ]; then wget https://phar.phpunit.de/phpunit.phar; fi
 
 install:
+  - if [[ "$DEPENDENCIES" = 'beta' ]]; then composer config minimum-stability beta; travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader; fi;
   - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable; fi
   - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable --prefer-lowest; fi
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.6 || ^7.0",
         "sebastian/finder-facade": "^1.1",
         "sebastian/version": "^2.0",
-        "symfony/console": "^2.7|^3.0"
+        "symfony/console": "^2.7|^3.0|^4.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Greetings from the #SymfonyConHackday2017. This PR allows to install phploc along with Symfony 4 components. Since Symfony 4 is still in beta, a travis job is added to the matrix that tests with beta dependencies.