### PR TITLE
Wrong exit code when no files were found to be scanned

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -97,7 +97,7 @@ class Command extends AbstractCommand
 
         if (!$count) {
             $output->writeln('No files found to scan');
-            exit(1);
+            exit(0);
         }
 
         $printer = new Text;


### PR DESCRIPTION
The commit https://github.com/sebastianbergmann/phpcpd/commit/ea9991b60259acf79a1ec6c94cac3866ca819e22 sets the exit code to 0 when no files were found to be scanned. I suggest to stay consistent and to apply the same rule for phploc.