### PR TITLE
Update master branch alias in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0-dev"
+            "dev-master": "5.0-dev"
         }
     }
 }


### PR DESCRIPTION
Apparently, the development of version 5 has been started on the master branch. However, composer.json still tells composer that it finds the 4.0 branch in master. This PR fixes this inconsistency.