### PR TITLE
Fix: Remove sudo configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
   global:
     - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest"
 
-sudo: false
-
 before_install:
   - ./tools/composer clear-cache
 


### PR DESCRIPTION
This PR

* [x] removes outdated `sudo` configuration from `.travis.yml`

💁‍♂️ For reference, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.