### PR TITLE
Count public and non-public class constants separately

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -325,8 +325,10 @@ class Analyser
 
                                 if ($visibility == \T_PUBLIC) {
                                     $this->collector->incrementPublicMethods();
-                                } else {
-                                    $this->collector->incrementNonPublicMethods();
+                                } elseif ($visibility == \T_PROTECTED) {
+                                    $this->collector->incrementProtectedMethods();
+                                } elseif ($visibility == \T_PRIVATE) {
+                                    $this->collector->incrementPrivateMethods();
                                 }
                             }
                         }

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -377,9 +377,9 @@ class Analyser
 
                     break;
                 case \T_CONST:
-                    $possibleScopeToken = $tokens[$i - 2];
-                    if (is_array($possibleScopeToken)
-                        && in_array($possibleScopeToken[0], [\T_PRIVATE, \T_PROTECTED])
+                    $possibleScopeToken = $this->getPreviousNonWhitespaceNonCommentTokenPos($tokens, $i);
+                    if ($possibleScopeToken !== false
+                        && in_array($tokens[$possibleScopeToken][0], [\T_PRIVATE, \T_PROTECTED])
                     ) {
                         $this->collector->incrementNonPublicClassConstants();
                     } else {
@@ -617,6 +617,30 @@ class Analyser
             }
 
             return $start - 1;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param int $start
+     *
+     * @return bool
+     */
+    private function getPreviousNonWhitespaceNonCommentTokenPos(array $tokens, int $start)
+    {
+        $previousTokenIndex = $start - 1;
+        if (isset($tokens[$previousTokenIndex])) {
+            if (in_array($tokens[$previousTokenIndex][0], [
+                    \T_WHITESPACE,
+                    \T_COMMENT,
+                    \T_DOC_COMMENT
+                ])
+            ) {
+                return $this->getPreviousNonWhitespaceNonCommentTokenPos($tokens, $previousTokenIndex);
+            }
+
+            return $previousTokenIndex;
         }
 
         return false;

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -229,12 +229,18 @@ class Analyser
                             $testClass = true;
                             $this->collector->incrementTestClasses();
                         } else {
-                            if (isset($tokens[$i - 2]) &&
-                                \is_array($tokens[$i - 2]) &&
-                                $tokens[$i - 2][0] == \T_ABSTRACT) {
+                            $classModifierToken = $this->getPreviousNonWhitespaceTokenPos($tokens, $i);
+                            if ($classModifierToken !== false &&
+                                $tokens[$classModifierToken][0] === \T_ABSTRACT
+                            ) {
                                 $this->collector->incrementAbstractClasses();
+                            } elseif (
+                                $classModifierToken !== false &&
+                                $tokens[$classModifierToken][0] === \T_FINAL
+                            ) {
+                                $this->collector->incrementFinalClasses();
                             } else {
-                                $this->collector->incrementConcreteClasses();
+                                $this->collector->incrementNonFinalClasses();
                             }
                         }
                     }

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -229,7 +229,7 @@ class Analyser
                             $testClass = true;
                             $this->collector->incrementTestClasses();
                         } else {
-                            $classModifierToken = $this->getPreviousNonWhitespaceTokenPos($tokens, $i);
+                            $classModifierToken = $this->getPreviousNonWhitespaceNonCommentTokenPos($tokens, $i);
                             if ($classModifierToken !== false &&
                                 $tokens[$classModifierToken][0] === \T_ABSTRACT
                             ) {

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -371,7 +371,14 @@ class Analyser
 
                     break;
                 case \T_CONST:
-                    $this->collector->incrementClassConstants();
+                    $possibleScopeToken = $tokens[$i - 2];
+                    if (is_array($possibleScopeToken)
+                        && in_array($possibleScopeToken[0], [\T_PRIVATE, \T_PROTECTED])
+                    ) {
+                        $this->collector->incrementNonPublicClassConstants();
+                    } else {
+                        $this->collector->incrementPublicClassConstants();
+                    }
 
                     break;
 

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -190,6 +190,7 @@ class Analyser
                         } elseif ($block == $className) {
                             $className         = null;
                             $testClass         = false;
+                            $this->collector->currentClassStop();
                             $this->collector->currentClassReset();
                         }
                     }
@@ -316,6 +317,8 @@ class Analyser
                             } elseif (!$testClass) {
                                 $isInMethod = true;
                                 $this->collector->currentMethodStart();
+
+                                $this->collector->currentClassIncrementMethods();
 
                                 if (!$static) {
                                     $this->collector->incrementNonStaticMethods();

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -200,9 +200,14 @@ class Collector
         $this->increment('global constants');
     }
 
-    public function incrementClassConstants(): void
+    public function incrementPublicClassConstants(): void
     {
-        $this->increment('class constants');
+        $this->increment('public class constants');
+    }
+
+    public function incrementNonPublicClassConstants(): void
+    {
+        $this->increment('non-public class constants');
     }
 
     public function incrementTestClasses(): void

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -160,9 +160,14 @@ class Collector
         $this->increment('abstract classes');
     }
 
-    public function incrementConcreteClasses(): void
+    public function incrementNonFinalClasses(): void
     {
-        $this->increment('concrete classes');
+        $this->increment('non-final classes');
+    }
+
+    public function incrementFinalClasses(): void
+    {
+        $this->increment('final classes');
     }
 
     public function incrementNonStaticMethods(): void

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -185,9 +185,14 @@ class Collector
         $this->increment('public methods');
     }
 
-    public function incrementNonPublicMethods(): void
+    public function incrementProtectedMethods(): void
     {
-        $this->increment('non-public methods');
+        $this->increment('protected methods');
+    }
+
+    public function incrementPrivateMethods(): void
+    {
+        $this->increment('private methods');
     }
 
     public function incrementNamedFunctions(): void

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -21,6 +21,8 @@ class Collector
 
     private $currentMethodLines = 0;
 
+    private $currentNumberOfMethods = 0;
+
     public function getPublisher()
     {
         return new Publisher($this->counts);
@@ -55,6 +57,12 @@ class Collector
         }
         $this->currentClassComplexity = 0;
         $this->currentClassLines      = 0;
+        $this->currentNumberOfMethods = 0;
+    }
+
+    public function currentClassStop(): void
+    {
+        $this->addToArray('methods per class', $this->currentNumberOfMethods);
     }
 
     public function currentClassIncrementComplexity(): void
@@ -71,6 +79,11 @@ class Collector
     {
         $this->currentMethodComplexity = 1;
         $this->currentMethodLines      = 0;
+    }
+
+    public function currentClassIncrementMethods(): void
+    {
+        $this->currentNumberOfMethods++;
     }
 
     public function currentMethodIncrementComplexity(): void

--- a/src/Log/Csv.php
+++ b/src/Log/Csv.php
@@ -34,6 +34,8 @@ class Csv
         'classes'                     => 'Classes',
         'abstractClasses'             => 'Abstract Classes',
         'concreteClasses'             => 'Concrete Classes',
+        'finalClasses'                => 'Final Classes',
+        'nonFinalClasses'             => 'Non-Final Classes',
         'llocClasses'                 => 'Classes Length (LLOC)',
         'methods'                     => 'Methods',
         'nonStaticMethods'            => 'Non-Static Methods',

--- a/src/Log/Csv.php
+++ b/src/Log/Csv.php
@@ -66,6 +66,7 @@ class Csv
         'llocByNof'                   => 'Average Function Length (LLOC)',
         'classLlocAvg'                => 'Average Class Length',
         'methodLlocAvg'               => 'Average Method Length',
+        'averageMethodsPerClass'      => 'Average Methods per Class',
         'constants'                   => 'Constants',
         'globalConstants'             => 'Global Constants',
         'classConstants'              => 'Class Constants',

--- a/src/Log/Csv.php
+++ b/src/Log/Csv.php
@@ -52,6 +52,8 @@ class Csv
         'constants'                   => 'Constants',
         'globalConstants'             => 'Global Constants',
         'classConstants'              => 'Class Constants',
+        'publicClassConstants'        => 'Public Class Constants',
+        'nonPublicClassConstants'     => 'Non-Public Class Constants',
         'attributeAccesses'           => 'Attribute Accesses',
         'instanceAttributeAccesses'   => 'Non-Static Attribute Accesses',
         'staticAttributeAccesses'     => 'Static Attribute Accesses',

--- a/src/Log/Csv.php
+++ b/src/Log/Csv.php
@@ -15,6 +15,19 @@ namespace SebastianBergmann\PHPLOC\Log;
 class Csv
 {
     /**
+     * Prints a result set.
+     *
+     * @param string $filename
+     */
+    public function printResult($filename, array $count): void
+    {
+        \file_put_contents(
+            $filename,
+            $this->getKeysLine($count) . $this->getValuesLine($count)
+        );
+    }
+
+    /**
      * Mapping between internal and human-readable metric names
      *
      * @var array
@@ -42,6 +55,8 @@ class Csv
         'staticMethods'               => 'Static Methods',
         'publicMethods'               => 'Public Methods',
         'nonPublicMethods'            => 'Non-Public Methods',
+        'protectedMethods'            => 'Protected Methods',
+        'privateMethods'              => 'Private Methods',
         'classCcnAvg'                 => 'Cyclomatic Complexity / Number of Classes' /* In Text output: 'Average Complexity per Class' */,
         'methodCcnAvg'                => 'Cyclomatic Complexity / Number of Methods',
         'functions'                   => 'Functions',
@@ -69,19 +84,6 @@ class Csv
         'testClasses'                 => 'Test Classes',
         'testMethods'                 => 'Test Methods',
     ];
-
-    /**
-     * Prints a result set.
-     *
-     * @param string $filename
-     */
-    public function printResult($filename, array $count): void
-    {
-        \file_put_contents(
-            $filename,
-            $this->getKeysLine($count) . $this->getValuesLine($count)
-        );
-    }
 
     /**
      * @return string

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -47,6 +47,9 @@ Size
       Average Method Length                 %10d
         Minimum Method Length               %10d
         Maximum Method Length               %10d
+      Average Methods Per Class             %10d
+        Minimum Methods Per Class           %10d
+        Maximum Methods Per Class           %10d
     Functions                               %10d (%.2f%%)
       Average Function Length               %10d
     Not in classes or functions             %10d (%.2f%%)
@@ -118,6 +121,9 @@ END;
                 $count['methodLlocAvg'],
                 $count['methodLlocMin'],
                 $count['methodLlocMax'],
+                $count['averageMethodsPerClass'],
+                $count['minimumMethodsPerClass'],
+                $count['maximumMethodsPerClass'],
                 $count['llocFunctions'],
                 $count['lloc'] > 0 ? ($count['llocFunctions'] / $count['lloc']) * 100 : 0,
                 $count['llocByNof'],

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -87,7 +87,8 @@ Structure
       Static Methods                        %10d (%.2f%%)
     Visibility
       Public Methods                        %10d (%.2f%%)
-      Non-Public Methods                    %10d (%.2f%%)
+      Protected Methods                     %10d (%.2f%%)
+      Private Methods                       %10d (%.2f%%)
   Functions                                 %10d
     Named Functions                         %10d (%.2f%%)
     Anonymous Functions                     %10d (%.2f%%)
@@ -165,8 +166,10 @@ END;
                 $count['methods'] > 0 ? ($count['staticMethods'] / $count['methods']) * 100 : 0,
                 $count['publicMethods'],
                 $count['methods'] > 0 ? ($count['publicMethods'] / $count['methods']) * 100 : 0,
-                $count['nonPublicMethods'],
-                $count['methods'] > 0 ? ($count['nonPublicMethods'] / $count['methods']) * 100 : 0,
+                $count['protectedMethods'],
+                $count['methods'] > 0 ? ($count['protectedMethods'] / $count['methods']) * 100 : 0,
+                $count['privateMethods'],
+                $count['methods'] > 0 ? ($count['privateMethods'] / $count['methods']) * 100 : 0,
                 $count['functions'],
                 $count['namedFunctions'],
                 $count['functions'] > 0 ? ($count['namedFunctions'] / $count['functions']) * 100 : 0,

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -79,6 +79,8 @@ Structure
   Classes                                   %10d
     Abstract Classes                        %10d (%.2f%%)
     Concrete Classes                        %10d (%.2f%%)
+      Final Classes                         %10d (%.2f%%)
+      Non-Final Classes                     %10d (%.2f%%)
   Methods                                   %10d
     Scope
       Non-Static Methods                    %10d (%.2f%%)
@@ -152,6 +154,10 @@ END;
                 $count['classes'] > 0 ? ($count['abstractClasses'] / $count['classes']) * 100 : 0,
                 $count['concreteClasses'],
                 $count['classes'] > 0 ? ($count['concreteClasses'] / $count['classes']) * 100 : 0,
+                $count['finalClasses'],
+                $count['concreteClasses'] > 0 ? ($count['finalClasses'] / $count['concreteClasses']) * 100 : 0,
+                $count['nonFinalClasses'],
+                $count['concreteClasses'] > 0 ? ($count['nonFinalClasses'] / $count['concreteClasses']) * 100 : 0,
                 $count['methods'],
                 $count['nonStaticMethods'],
                 $count['methods'] > 0 ? ($count['nonStaticMethods'] / $count['methods']) * 100 : 0,

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -92,6 +92,8 @@ Structure
   Constants                                 %10d
     Global Constants                        %10d (%.2f%%)
     Class Constants                         %10d (%.2f%%)
+      Public Constants                      %10d (%.2f%%)
+      Non-Public Constants                  %10d (%.2f%%)
 
 END;
 
@@ -168,7 +170,11 @@ END;
                 $count['globalConstants'],
                 $count['constants'] > 0 ? ($count['globalConstants'] / $count['constants']) * 100 : 0,
                 $count['classConstants'],
-                $count['constants'] > 0 ? ($count['classConstants'] / $count['constants']) * 100 : 0
+                $count['constants'] > 0 ? ($count['classConstants'] / $count['constants']) * 100 : 0,
+                $count['publicClassConstants'],
+                $count['classConstants'] > 0 ? ($count['publicClassConstants'] / $count['classConstants']) * 100 : 0,
+                $count['nonPublicClassConstants'],
+                $count['classConstants'] > 0 ? ($count['nonPublicClassConstants'] / $count['classConstants']) * 100 : 0
             )
         );
 

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -220,7 +220,17 @@ class Publisher
 
     public function getConcreteClasses()
     {
-        return $this->getValue('concrete classes');
+        return $this->getFinalClasses() + $this->getNonFinalClasses();
+    }
+
+    public function getFinalClasses()
+    {
+        return $this->getValue('final classes');
+    }
+
+    public function getNonFinalClasses()
+    {
+        return $this->getValue('non-final classes');
     }
 
     public function getMethods()
@@ -315,6 +325,8 @@ class Publisher
             'classes'                     => $this->getClasses(),
             'abstractClasses'             => $this->getAbstractClasses(),
             'concreteClasses'             => $this->getConcreteClasses(),
+            'finalClasses'                => $this->getFinalClasses(),
+            'nonFinalClasses'             => $this->getNonFinalClasses(),
             'functions'                   => $this->getFunctions(),
             'namedFunctions'              => $this->getNamedFunctions(),
             'anonymousFunctions'          => $this->getAnonymousFunctions(),

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -273,9 +273,19 @@ class Publisher
         return $this->getValue('global constants');
     }
 
+    public function getPublicClassConstants()
+    {
+        return $this->getValue('public class constants');
+    }
+
+    public function getNonPublicClassConstants()
+    {
+        return $this->getValue('non-public class constants');
+    }
+
     public function getClassConstants()
     {
-        return $this->getValue('class constants');
+        return $this->getPublicClassConstants() + $this->getNonPublicClassConstants();
     }
 
     public function getTestClasses()
@@ -315,6 +325,8 @@ class Publisher
             'staticMethods'               => $this->getStaticMethods(),
             'constants'                   => $this->getConstants(),
             'classConstants'              => $this->getClassConstants(),
+            'publicClassConstants'        => $this->getPublicClassConstants(),
+            'nonPublicClassConstants'     => $this->getNonPublicClassConstants(),
             'globalConstants'             => $this->getGlobalConstants(),
             'testClasses'                 => $this->getTestClasses(),
             'testMethods'                 => $this->getTestMethods(),

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -83,6 +83,21 @@ class Publisher
         return $this->getMaximum('method lines');
     }
 
+    public function getAverageMethodsPerClass()
+    {
+        return $this->getAverage('methods per class');
+    }
+
+    public function getMinimumMethodsPerClass()
+    {
+        return $this->getMinimum('methods per class');
+    }
+
+    public function getMaximumMethodsPerClass()
+    {
+        return $this->getMaximum('methods per class');
+    }
+
     public function getFunctionLines()
     {
         return $this->getValue('function lines');
@@ -379,6 +394,9 @@ class Publisher
             'methodLlocMin'               => $this->getMinimumMethodLength(),
             'methodLlocAvg'               => $this->getAverageMethodLength(),
             'methodLlocMax'               => $this->getMaximumMethodLength(),
+            'averageMethodsPerClass'      => $this->getAverageMethodsPerClass(),
+            'minimumMethodsPerClass'      => $this->getMinimumMethodsPerClass(),
+            'maximumMethodsPerClass'      => $this->getMaximumMethodsPerClass(),
             'namespaces'                  => $this->getNamespaces(),
             'ncloc'                       => $this->getNonCommentLines(),
         ];

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -255,7 +255,17 @@ class Publisher
 
     public function getNonPublicMethods()
     {
-        return $this->getValue('non-public methods');
+        return $this->getProtectedMethods() + $this->getPrivateMethods();
+    }
+
+    public function getProtectedMethods()
+    {
+        return $this->getValue('protected methods');
+    }
+
+    public function getPrivateMethods()
+    {
+        return $this->getValue('private methods');
     }
 
     public function getFunctions()
@@ -333,6 +343,8 @@ class Publisher
             'methods'                     => $this->getMethods(),
             'publicMethods'               => $this->getPublicMethods(),
             'nonPublicMethods'            => $this->getNonPublicMethods(),
+            'protectedMethods'            => $this->getProtectedMethods(),
+            'privateMethods'              => $this->getPrivateMethods(),
             'nonStaticMethods'            => $this->getNonStaticMethods(),
             'staticMethods'               => $this->getStaticMethods(),
             'constants'                   => $this->getConstants(),

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -351,9 +351,9 @@ class AnalyserTest extends TestCase
     {
         $result = $this->analyser->countFiles([__DIR__ . '/_files/class_constants.php'], false);
         $this->assertEquals(2, $result['publicClassConstants']);
-        $this->assertEquals(2, $result['nonPublicClassConstants']);
-        $this->assertEquals(4, $result['classConstants']);
-        $this->assertEquals(4, $result['constants']);
+        $this->assertEquals(3, $result['nonPublicClassConstants']);
+        $this->assertEquals(5, $result['classConstants']);
+        $this->assertEquals(5, $result['constants']);
     }
 
     public function test_it_collects_the_number_of_final_non_final_and_abstract_classes(): void

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -359,9 +359,9 @@ class AnalyserTest extends TestCase
     public function test_it_collects_the_number_of_final_non_final_and_abstract_classes(): void
     {
         $result = $this->analyser->countFiles([__DIR__ . '/_files/classes.php'], false);
-        $this->assertEquals(6, $result['classes']);
+        $this->assertEquals(9, $result['classes']);
         $this->assertEquals(2, $result['finalClasses']);
         $this->assertEquals(3, $result['nonFinalClasses']);
-        $this->assertEquals(1, $result['abstractClasses']);
+        $this->assertEquals(4, $result['abstractClasses']);
     }
 }

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -41,6 +41,8 @@ class AnalyserTest extends TestCase
                 'classes'                     => 2,
                 'abstractClasses'             => 1,
                 'concreteClasses'             => 1,
+                'nonFinalClasses'             => 1,
+                'finalClasses'                => 0,
                 'functions'                   => 2,
                 'namedFunctions'              => 1,
                 'anonymousFunctions'          => 1,
@@ -110,6 +112,8 @@ class AnalyserTest extends TestCase
                 'classes'                     => 2,
                 'abstractClasses'             => 1,
                 'concreteClasses'             => 1,
+                'nonFinalClasses'             => 1,
+                'finalClasses'                => 0,
                 'functions'                   => 2,
                 'namedFunctions'              => 1,
                 'anonymousFunctions'          => 1,
@@ -350,5 +354,14 @@ class AnalyserTest extends TestCase
         $this->assertEquals(2, $result['nonPublicClassConstants']);
         $this->assertEquals(4, $result['classConstants']);
         $this->assertEquals(4, $result['constants']);
+    }
+
+    public function test_it_collects_the_number_of_final_non_final_and_abstract_classes(): void
+    {
+        $result = $this->analyser->countFiles([__DIR__ . '/_files/classes.php'], false);
+        $this->assertEquals(3, $result['classes']);
+        $this->assertEquals(1, $result['finalClasses']);
+        $this->assertEquals(1, $result['nonFinalClasses']);
+        $this->assertEquals(1, $result['abstractClasses']);
     }
 }

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -51,6 +51,8 @@ class AnalyserTest extends TestCase
                 'staticMethods'               => 1,
                 'constants'                   => 2,
                 'classConstants'              => 1,
+                'publicClassConstants'        => 1,
+                'nonPublicClassConstants'     => 0,
                 'globalConstants'             => 1,
                 'testClasses'                 => 0,
                 'testMethods'                 => 0,
@@ -117,6 +119,8 @@ class AnalyserTest extends TestCase
                 'nonStaticMethods'            => 3,
                 'staticMethods'               => 1,
                 'constants'                   => 2,
+                'publicClassConstants'        => 1,
+                'nonPublicClassConstants'     => 0,
                 'classConstants'              => 1,
                 'globalConstants'             => 1,
                 'testClasses'                 => 1,
@@ -337,5 +341,14 @@ class AnalyserTest extends TestCase
         $result = $this->analyser->countFiles([__DIR__ . '/_files/with_import.php'], false);
 
         $this->assertEquals(0, $result['llocGlobal']);
+    }
+
+    public function test_it_makes_a_distinction_between_public_and_non_public_class_constants(): void
+    {
+        $result = $this->analyser->countFiles([__DIR__ . '/_files/class_constants.php'], false);
+        $this->assertEquals(2, $result['publicClassConstants']);
+        $this->assertEquals(2, $result['nonPublicClassConstants']);
+        $this->assertEquals(4, $result['classConstants']);
+        $this->assertEquals(4, $result['constants']);
     }
 }

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -49,6 +49,8 @@ class AnalyserTest extends TestCase
                 'methods'                     => 4,
                 'publicMethods'               => 2,
                 'nonPublicMethods'            => 2,
+                'protectedMethods'            => 1,
+                'privateMethods'              => 1,
                 'nonStaticMethods'            => 3,
                 'staticMethods'               => 1,
                 'constants'                   => 2,
@@ -120,6 +122,8 @@ class AnalyserTest extends TestCase
                 'methods'                     => 4,
                 'publicMethods'               => 2,
                 'nonPublicMethods'            => 2,
+                'protectedMethods'            => 1,
+                'privateMethods'              => 1,
                 'nonStaticMethods'            => 3,
                 'staticMethods'               => 1,
                 'constants'                   => 2,
@@ -363,5 +367,14 @@ class AnalyserTest extends TestCase
         $this->assertEquals(2, $result['finalClasses']);
         $this->assertEquals(3, $result['nonFinalClasses']);
         $this->assertEquals(4, $result['abstractClasses']);
+    }
+
+    public function test_it_makes_a_distinction_between_protected_and_private_methods(): void
+    {
+        $result = $this->analyser->countFiles([__DIR__ . '/_files/methods.php'], false);
+        $this->assertEquals(2, $result['publicMethods']);
+        $this->assertEquals(1, $result['protectedMethods']);
+        $this->assertEquals(3, $result['privateMethods']);
+        $this->assertEquals(6, $result['methods']);
     }
 }

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -87,6 +87,9 @@ class AnalyserTest extends TestCase
                 'methodLlocMin'               => 4,
                 'methodLlocAvg'               => 5.6,
                 'methodLlocMax'               => 7,
+                'averageMethodsPerClass'      => 1.33,
+                'minimumMethodsPerClass'      => 0,
+                'maximumMethodsPerClass'      => 4
             ],
             $this->analyser->countFiles(
                 [__DIR__ . '/_files/source.php'],
@@ -160,6 +163,9 @@ class AnalyserTest extends TestCase
                 'methodLlocMin'               => 4,
                 'methodLlocAvg'               => 5.6,
                 'methodLlocMax'               => 7,
+                'averageMethodsPerClass'      => 1,
+                'minimumMethodsPerClass'      => 0,
+                'maximumMethodsPerClass'      => 4
             ],
             $this->analyser->countFiles(
                 [
@@ -376,5 +382,13 @@ class AnalyserTest extends TestCase
         $this->assertEquals(1, $result['protectedMethods']);
         $this->assertEquals(3, $result['privateMethods']);
         $this->assertEquals(6, $result['methods']);
+    }
+
+    public function test_it_provides_average_minimum_and_maximum_number_of_methods_per_class(): void
+    {
+        $result = $this->analyser->countFiles([__DIR__ . '/_files/methods_per_class.php'], false);
+        $this->assertEquals(2, $result['averageMethodsPerClass']);
+        $this->assertEquals(0, $result['minimumMethodsPerClass']);
+        $this->assertEquals(4, $result['maximumMethodsPerClass']);
     }
 }

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -359,9 +359,9 @@ class AnalyserTest extends TestCase
     public function test_it_collects_the_number_of_final_non_final_and_abstract_classes(): void
     {
         $result = $this->analyser->countFiles([__DIR__ . '/_files/classes.php'], false);
-        $this->assertEquals(3, $result['classes']);
-        $this->assertEquals(1, $result['finalClasses']);
-        $this->assertEquals(1, $result['nonFinalClasses']);
+        $this->assertEquals(6, $result['classes']);
+        $this->assertEquals(2, $result['finalClasses']);
+        $this->assertEquals(3, $result['nonFinalClasses']);
         $this->assertEquals(1, $result['abstractClasses']);
     }
 }

--- a/tests/Log/SingleTest.php
+++ b/tests/Log/SingleTest.php
@@ -48,6 +48,8 @@ class SingleTest extends TestCase
         'constants'                   => 27,
         'globalConstants'             => 28,
         'classConstants'              => 29,
+        'publicClassConstants'        => 15,
+        'nonPublicClassConstants'     => 14,
         'attributeAccesses'           => 30,
         'instanceAttributeAccesses'   => 31,
         'staticAttributeAccesses'     => 32,

--- a/tests/Log/SingleTest.php
+++ b/tests/Log/SingleTest.php
@@ -33,6 +33,8 @@ class SingleTest extends TestCase
         'classes'                     => 12,
         'abstractClasses'             => 13,
         'concreteClasses'             => 14,
+        'finalClasses'                => 8,
+        'nonFinalClasses'             => 6,
         'llocClasses'                 => 15,
         'methods'                     => 16,
         'nonStaticMethods'            => 17,

--- a/tests/Log/SingleTest.php
+++ b/tests/Log/SingleTest.php
@@ -41,6 +41,8 @@ class SingleTest extends TestCase
         'staticMethods'               => 18,
         'publicMethods'               => 19,
         'nonPublicMethods'            => 20,
+        'protectedMethods'            => 14,
+        'privateMethods'              => 6,
         'methodCcnAvg'                => 21,
         'functions'                   => 22,
         'namedFunctions'              => 23,

--- a/tests/Log/SingleTest.php
+++ b/tests/Log/SingleTest.php
@@ -69,6 +69,7 @@ class SingleTest extends TestCase
         'classCcnAvg'                 => 42,
         'classLlocAvg'                => 43,
         'methodLlocAvg'               => 44,
+        'averageMethodsPerClass'      => 5
     ];
 
     protected function setUp(): void

--- a/tests/_files/class_constants.php
+++ b/tests/_files/class_constants.php
@@ -1,0 +1,9 @@
+<?php
+
+class ClassConstants
+{
+    const IMPLICITLY_PUBLIC_CONSTANT = 'implicitly public';
+    public const EXPLICITLY_PUBLIC_CONSTANT = 'explicitly public';
+    private const PRIVATE_CONSTANT = 'private';
+    protected const PROTECTED_CONSTANT = 'protected';
+}

--- a/tests/_files/class_constants.php
+++ b/tests/_files/class_constants.php
@@ -4,6 +4,7 @@ class ClassConstants
 {
     const IMPLICITLY_PUBLIC_CONSTANT = 'implicitly public';
     public const EXPLICITLY_PUBLIC_CONSTANT = 'explicitly public';
+    private /* a comment might be here */ const COMMENT_IN_DEFINTION = 'comment in definition';
     private const PRIVATE_CONSTANT = 'private';
     protected const PROTECTED_CONSTANT = 'protected';
 }

--- a/tests/_files/classes.php
+++ b/tests/_files/classes.php
@@ -1,0 +1,16 @@
+<?php
+
+final class FinalClass
+{
+
+}
+
+class NonFinalClass
+{
+
+}
+
+abstract class AbstractClass
+{
+
+}

--- a/tests/_files/classes.php
+++ b/tests/_files/classes.php
@@ -5,7 +5,7 @@ final class FinalClass1
 
 }
 
-final class FinalClass2
+final /* comment */ class FinalClass2
 {
 
 }
@@ -25,7 +25,22 @@ class NonFinalClass3
 
 }
 
-abstract class AbstractClass
+abstract class AbstractClass1
+{
+
+}
+
+abstract class AbstractClass2
+{
+
+}
+
+abstract class AbstractClass3
+{
+
+}
+
+abstract /* a comment */ class AbstractClass4
 {
 
 }

--- a/tests/_files/classes.php
+++ b/tests/_files/classes.php
@@ -1,11 +1,26 @@
 <?php
 
-final class FinalClass
+final class FinalClass1
 {
 
 }
 
-class NonFinalClass
+final class FinalClass2
+{
+
+}
+
+class NonFinalClass1
+{
+
+}
+
+class NonFinalClass2
+{
+
+}
+
+class NonFinalClass3
 {
 
 }

--- a/tests/_files/methods.php
+++ b/tests/_files/methods.php
@@ -1,0 +1,31 @@
+<?php
+
+class Methods1
+{
+    function undefinedVisibilityBecomesPublicVisibility1()
+    {
+    }
+
+    public function publicVisibility2()
+    {
+    }
+
+    protected /* a comment here */ function protectedVisibility1()
+    {
+    }
+
+    private function privateVisibility1()
+    {
+    }
+}
+
+class Methods2
+{
+    private function privateVisibility2()
+    {
+    }
+
+    private /* a comment here */ function privateVisibility3()
+    {
+    }
+}

--- a/tests/_files/methods_per_class.php
+++ b/tests/_files/methods_per_class.php
@@ -1,0 +1,36 @@
+<?php
+
+class MethodsPerClass1
+{
+    // no methods
+}
+
+class MethodsPerClass2
+{
+    public function method1()
+    {
+    }
+
+    public function method2()
+    {
+    }
+}
+
+class MethodsPerClass3
+{
+    public function method1()
+    {
+    }
+
+    public function method2()
+    {
+    }
+
+    public function method3()
+    {
+    }
+
+    public function method4()
+    {
+    }
+}


### PR DESCRIPTION
This PR introduces two metrics which offer a more detailed view on the use of class constants in a project, making a distinction between public and non-public class constants.

```
  Constants                                       5181
    Global Constants                                13 (0.25%)
    Class Constants                               5168 (99.75%)
      Public Constants                            5154 (99.73%)
      Non-Public Constants                          14 (0.27%)
```

Please let me know what you think. I have a couple of extra suggestions that I'd like to implement as well (https://matthiasnoback.nl/2019/09/using-phploc-for-quick-code-quality-estimation-part-2/), hence the branch name :) Thanks for this awesome tool!

[edit]
I just added another feature that I think is very useful: separating concrete classes into final and non-final classes.

```
  Classes                                         1788
    Abstract Classes                                25 (1.40%)
    Concrete Classes                              1763 (98.60%)
      Final Classes                                804 (45.60%)
      Non-Final Classes                            959 (54.40%)
```

[edit]
I've added the following section to "Size":
```
      Average Methods Per Class                      5
        Minimum Methods Per Class                    0
        Maximum Methods Per Class                  187
```

Furthermore, I thought it would be useful to make a difference between private and protected methods:

```
    Visibility
      Public Methods                              8460 (84.48%)
      Protected Methods                            646 (6.45%)
      Private Methods                              908 (9.07%)
```