### PR TITLE
Updated ini_set to honor strict_types

### DIFF
--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -104,10 +104,10 @@ class Application extends AbstractApplication
             return;
         }
 
-        \ini_set('xdebug.scream', 0);
-        \ini_set('xdebug.max_nesting_level', 8192);
-        \ini_set('xdebug.show_exception_trace', 0);
-        \ini_set('xdebug.show_error_trace', 0);
+        \ini_set('xdebug.scream', '0');
+        \ini_set('xdebug.max_nesting_level', '8192');
+        \ini_set('xdebug.show_exception_trace', '0');
+        \ini_set('xdebug.show_error_trace', '0');
 
         \xdebug_disable();
     }


### PR DESCRIPTION
After adding `declare(strict_types=1);` on https://github.com/sebastianbergmann/phploc/blob/master/src/CLI/Application.php#L1

A problem occurred on https://github.com/sebastianbergmann/phploc/blob/master/src/CLI/Application.php#L107-L110

Making parameter 2 a string should fix this problem.