### PR TITLE
Bugfix: ini_set() expects a string as second parameter

### DIFF
--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -104,10 +104,10 @@ class Application extends AbstractApplication
             return;
         }
 
-        \ini_set('xdebug.scream', 0);
-        \ini_set('xdebug.max_nesting_level', 8192);
-        \ini_set('xdebug.show_exception_trace', 0);
-        \ini_set('xdebug.show_error_trace', 0);
+        \ini_set('xdebug.scream', '0');
+        \ini_set('xdebug.max_nesting_level', '8192');
+        \ini_set('xdebug.show_exception_trace', '0');
+        \ini_set('xdebug.show_error_trace', '0');
 
         \xdebug_disable();
     }


### PR DESCRIPTION
Fixes #204.

When running phploc, I get the following error:

```
HP Fatal error:  Uncaught TypeError: ini_set() expects parameter 2 to be string, int given in phar:///home/rabus/.phive/phars/phploc-6.0.0.phar/src/CLI/Application.php:107
Stack trace:
#0 phar:///home/rabus/.phive/phars/phploc-6.0.0.phar/src/CLI/Application.php(107): ini_set('xdebug.scream', 0)
#1 phar:///home/rabus/.phive/phars/phploc-6.0.0.phar/src/CLI/Application.php(52): SebastianBergmann\PHPLOC\CLI\Application->disableXdebug()
#2 phar:///home/rabus/.phive/phars/phploc-6.0.0.phar/symfony/console/Application.php(141): SebastianBergmann\PHPLOC\CLI\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /home/rabus/.phive/phars/phploc-6.0.0.phar(179): Symfony\Component\Console\Application->run()
#4 {main}
  thrown in phar:///home/rabus/.phive/phars/phploc-6.0.0.phar/src/CLI/Application.php on line 107
```

This PR should fix the problem.