### PR TITLE
Fix undefined index notice

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -547,7 +547,7 @@ final class Analyser
 
         $namespaced = $className === '\\';
 
-        while (is_array($tokens[$i + 1]) && $tokens[$i + 1][0] !== T_WHITESPACE) {
+        while (isset($tokens[$i + 1]) && is_array($tokens[$i + 1]) && $tokens[$i + 1][0] !== T_WHITESPACE) {
             $className .= $tokens[++$i][1];
         }
 


### PR DESCRIPTION
Occurs for example while analysing php-code-coverage with phploc:

```
$ php7.4 vendor/bin/phploc phpunit/php-code-coverage
phploc 7.0.1 by Sebastian Bergmann.

PHP Notice:  Undefined offset: 7 in /path/vendor/phploc/phploc/src/Analyser.php on line 550
PHP Stack trace:
PHP   1. {main}() /path/vendor/phploc/phploc/phploc:0
PHP   2. SebastianBergmann\PHPLOC\Application->run() /path/vendor/phploc/phploc/phploc:30
PHP   3. SebastianBergmann\PHPLOC\Analyser->countFiles() /path/vendor/phploc/phploc/src/CLI/Application.php:62
PHP   4. SebastianBergmann\PHPLOC\Analyser->countFile() /path/vendor/phploc/phploc/src/Analyser.php:105
PHP   5. SebastianBergmann\PHPLOC\Analyser->getClassName() /path/vendor/phploc/phploc/src/Analyser.php:260
Directories                                         10
Files                                               94
...
```