### PR TITLE
Add --quiet command line argument

### DIFF
--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -61,7 +61,9 @@ final class Application
 
         $result = (new Analyser)->countFiles($files, $arguments->countTests());
 
-        (new TextPrinter)->printResult($result, $arguments->countTests());
+        if (!$arguments->quiet()) {
+            (new TextPrinter)->printResult($result, $arguments->countTests());
+        }
 
         if ($arguments->csvLogfile()) {
             $printer = new CsvPrinter;

--- a/src/CLI/Arguments.php
+++ b/src/CLI/Arguments.php
@@ -54,9 +54,14 @@ final class Arguments
     /**
      * @var bool
      */
+    private $quiet;
+
+    /**
+     * @var bool
+     */
     private $version;
 
-    public function __construct(array $directories, array $suffixes, array $exclude, bool $countTests, ?string $csvLogfile, ?string $jsonLogfile, ?string $xmlLogfile, bool $help, bool $version)
+    public function __construct(array $directories, array $suffixes, array $exclude, bool $countTests, ?string $csvLogfile, ?string $jsonLogfile, ?string $xmlLogfile, bool $help, bool $quiet, bool $version)
     {
         $this->directories = $directories;
         $this->suffixes    = $suffixes;
@@ -66,6 +71,7 @@ final class Arguments
         $this->jsonLogfile = $jsonLogfile;
         $this->xmlLogfile  = $xmlLogfile;
         $this->help        = $help;
+        $this->quiet       = $quiet;
         $this->version     = $version;
     }
 
@@ -116,6 +122,11 @@ final class Arguments
     public function help(): bool
     {
         return $this->help;
+    }
+
+    public function quiet(): bool
+    {
+        return $this->quiet;
     }
 
     public function version(): bool

--- a/src/CLI/ArgumentsBuilder.php
+++ b/src/CLI/ArgumentsBuilder.php
@@ -22,7 +22,7 @@ final class ArgumentsBuilder
         try {
             $options = (new CliParser)->parse(
                 $argv,
-                'hv',
+                'hqv',
                 [
                     'suffix=',
                     'exclude=',
@@ -31,6 +31,7 @@ final class ArgumentsBuilder
                     'log-json=',
                     'log-xml=',
                     'help',
+                    'quiet',
                     'version',
                 ]
             );
@@ -50,6 +51,7 @@ final class ArgumentsBuilder
         $jsonLogfile = null;
         $xmlLogfile  = null;
         $help        = false;
+        $quiet       = false;
         $version     = false;
 
         foreach ($options[0] as $option) {
@@ -90,6 +92,12 @@ final class ArgumentsBuilder
 
                     break;
 
+                case 'q':
+                case '--quiet':
+                    $quiet = true;
+
+                    break;
+
                 case 'v':
                 case '--version':
                     $version = true;
@@ -113,6 +121,7 @@ final class ArgumentsBuilder
             $jsonLogfile,
             $xmlLogfile,
             $help,
+            $quiet,
             $version,
         );
     }


### PR DESCRIPTION
This pull request re-introduce the `--quiet` `-q` argument in the command line.

Having this option is particularly useful when using **phploc** programmatically, to get a machine-readable format by streaming the output to stdout `phploc -q --log-json=/dev/stdout` without having to trim manually the default text output.

