### PR TITLE
Fix trailing ',' in return Arguments Contructor

### DIFF
--- a/src/CLI/ArgumentsBuilder.php
+++ b/src/CLI/ArgumentsBuilder.php
@@ -113,7 +113,7 @@ final class ArgumentsBuilder
             $jsonLogfile,
             $xmlLogfile,
             $help,
-            $version,
+            $version
         );
     }
 }


### PR DESCRIPTION
The trailing ',' in this object contrsuctor was causing a parse error:

```
phploc 7.0.2 by Sebastian Bergmann.
PHP Parse error:  syntax error, unexpected ')' in /usr/local/src/phploc/src/CLI/ArgumentsBuilder.php on line 117

Parse error: syntax error, unexpected ')' in /usr/local/src/phploc/src/CLI/ArgumentsBuilder.php on line 117
```