### PR TITLE
Fixed version 4.0.1 for XDebug version 3.

### DIFF
--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -109,6 +109,8 @@ class Application extends AbstractApplication
         \ini_set('xdebug.show_exception_trace', 0);
         \ini_set('xdebug.show_error_trace', 0);
 
-        \xdebug_disable();
+        if (\function_exists('xdebug_disable')) {
+            \xdebug_disable();
+        }
     }
 }


### PR DESCRIPTION
I should support project which still has minimal PHP version 5.6. And project use latest PHPLoc version with PHP 5.6 support (It is a 4.0.1). For now PHPLoc 4.0.1 broken if you are using XDebug version 3+.

I know that you are not support now version 4, but could you release patch 4.0.2 if it is not very difficult? Thanks.